### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16
+
+COPY ./ /go/src/github.com/hawkinsw/qperf
+WORKDIR /go/src/github.com/hawkinsw/qperf/server
+# TODO: can we build server using `go get` and local sources?
+RUN go build .
+RUN cp server /go/bin/
+
+ENTRYPOINT ["/go/bin/server"]


### PR DESCRIPTION
This change adds a basic Dockerfile that builds and runs the QUIC server. All server flags must be specified at run time.